### PR TITLE
Studios confirming/declining their acceptance

### DIFF
--- a/mivs/automated_emails.py
+++ b/mivs/automated_emails.py
@@ -39,6 +39,9 @@ MIVSEmail(IndieGame, 'Your game application has been declined from MIVS', 'game_
 MIVSEmail(IndieGame, 'Your MIVS application has been waitlisted', 'game_waitlisted.txt',
           lambda game: game.status == c.WAITLISTED)
 
+MIVSEmail(IndieGame, 'Last chance to accept you MIVS booth', 'game_accept_reminder.txt',
+          lambda game: game.status == c.ACCEPTED and days_before(2, c.MIVS_CONFIRM_DEADLINE))
+
 MIVSEmail(IndieGame, 'MIVS judging is wrapping up', 'round_two_closing.txt',
           lambda game: game.submitted and days_before(14, c.JUDGING_DEADLINE))
 

--- a/mivs/config.py
+++ b/mivs/config.py
@@ -19,5 +19,7 @@ c.INDIE_JUDGE_GENRE_OPTS.insert(0, (c.ALL_GENRES, _all_genres_desc))
 
 c.PROBLEM_STATUSES = {getattr(c, status.upper()) for status in c.PROBLEM_STATUSES.split(',')}
 
+c.FINAL_GAME_STATUSES = [c.ACCEPTED, c.WAITLISTED, c.DECLINED, c.STUDIO_DECLINED]
+
 # used for computing the difference between the "drop-dead deadline" and the "soft deadline"
 c.SOFT_JUDGING_DEADLINE = c.JUDGING_DEADLINE - timedelta(days=7)

--- a/mivs/configspec.ini
+++ b/mivs/configspec.ini
@@ -45,6 +45,7 @@ round_one_deadline = string(default="2015-10-31")
 round_two_deadline = string(default="2015-11-30")
 judging_deadline = string(default="2016-01-03")
 round_two_complete = string(default="2016-01-09")
+mivs_confirm_deadline = string(default="2016-01-15")
 
 
 [enums]
@@ -107,6 +108,7 @@ release = string(default="Release")
 new = string(default="Round One")
 judging = string(default="Accepted Into Round Two")
 video_declined = string(default="Video Declined")
-game_declined = string(default="Game Declined")
+game_declined = string(default="declined")
 waitlisted = string(default="waitlisted")
 accepted = string(default="accepted")
+studio_declined = string(default="studio backed out")

--- a/mivs/templates/emails/game_accept_reminder.txt
+++ b/mivs/templates/emails/game_accept_reminder.txt
@@ -1,0 +1,9 @@
+{{ game.studio.primary_contact.first_name }},
+
+Congratulations again for your game submission ({{ game.title }}) being accepted into the 2016 MAGFest Indie Videogame Showcase (MIVS).
+
+You still haven't told us whether or not you accept the offer of a table in the showcase, which you may do at {{ c.URL_BASE }}/mivs_applications/continue_app?id={{ game.studio.id }}
+
+You must accept or decline the space by {{ c.MIVS_CONFIRM_DEADLINE|datetime }}.  Telling us you aren't able to meet the requirements leaves your team on good terms with the MIVS staff; failing to show or not meeting the requirements will be taken into consideration for future events.
+
+{{ c.MIVS_EMAIL_SIGNATURE }}

--- a/mivs/templates/emails/game_accepted.txt
+++ b/mivs/templates/emails/game_accepted.txt
@@ -6,7 +6,7 @@ Congratulations!  Your game submission ({{ game.title }}) for the 2016 MAGFest I
 
 Please confirm that you are coming OR let us know that you cannot make it after all at {{ c.URL_BASE }}/mivs_applications/continue_app?id={{ game.studio.id }}
 
-You have until {{ c.MIVS_CONFIRM_DEADLINE|datetime }} to confirm.
+You have until {{ c.MIVS_CONFIRM_DEADLINE|datetime }} to confirm (or decline).
 
 We'd much rather you explicitly decline than to just fade, as being prompt helps us to move indies who are on the waitlist into the showcase.
 

--- a/mivs/templates/emails/game_accepted.txt
+++ b/mivs/templates/emails/game_accepted.txt
@@ -1,5 +1,22 @@
 {{ game.studio.primary_contact.first_name }},
 
-placeholder text, will get email text from MIVS folks later
+Congratulations!  Your game submission ({{ game.title }}) for the 2016 MAGFest Indie Videogame Showcase (MIVS) is one of the 55 that have been accepted into the showcase.
+
+*** YOU NEED TO CONFIRM YOUR ACCEPTANCE! ***
+
+Please confirm that you are coming OR let us know that you cannot make it after all at {{ c.URL_BASE }}/mivs_applications/continue_app?id={{ game.studio.id }}
+
+You have until {{ c.MIVS_CONFIRM_DEADLINE|datetime }} to confirm.
+
+We'd much rather you explicitly decline than to just fade, as being prompt helps us to move indies who are on the waitlist into the showcase.
+
+More details will be sent out to all those who confirm including:
+- Opportunity to buy a hotel room in the Gaylord (yes we saved a block for sale to the indies this year)
+- What's included in a MIVS "booth" space
+- much, much more....
+
+Again, we understand that things may come up which may prevent your team from meeting the above requirements.  If this is the case, please let us know ASAP as this will allow one of our many wait-listed entries to participate.
+
+Telling us you aren't able to meet the requirements leaves your team on good terms with the MIVS staff; failing to show or not meeting the requirements will be taken into consideration for future events.
 
 {{ c.MIVS_EMAIL_SIGNATURE }}

--- a/mivs/templates/emails/game_declined.txt
+++ b/mivs/templates/emails/game_declined.txt
@@ -1,5 +1,13 @@
 {{ game.studio.primary_contact.first_name }},
 
-placeholder text, will get email text from MIVS folks later
+Thank you for your game submission ({{ game.title }}) to the MAGFest Indie Videogame Showcase (MIVS).
+
+We regret to inform you that your team's scores did not qualify for booth space at MIVS.
+
+If you'd still like to show your game in the MIVS area at MAGFest, you still have the opportunity with "QuickPlay"!
+
+QuickPlay is an area at MIVS where tables are set aside for indies to show their game for a block of time.  As an indie, you'll be able to sign up for a 2 hour block of time, with possibly more blocks depending on availability.  We will provide a table, 2 chairs, and power.  You will need to provide your own equipment.  (WIFI/Network connections will not be available.)
+
+Signups for Quickplay will not happen online, they will only be available on-site at MAGFest in the MIVS area and will require you to have purchased a MAGFest badge.  Signups will be on a first come first serve basis, so we recommend visiting the MIVS area at your first convenience after picking up your MAGFest badge.
 
 {{ c.MIVS_EMAIL_SIGNATURE }}

--- a/mivs/templates/emails/game_waitlisted.txt
+++ b/mivs/templates/emails/game_waitlisted.txt
@@ -1,5 +1,15 @@
 {{ game.studio.primary_contact.first_name }},
 
-placeholder text, will get email text from MIVS folks later
+Thank you for your game submission ({{ game.title }}) to the MAGFest Indie Videogame Showcase (MIVS).
+
+Your studio's entry was judged high enough to qualify for the MIVS area but we do not have enough space to host your team, so we've added you to our Waitlist.
+
+This means that if other indies who have been placed in MIVS end up not being able to show for any reason, we'll ask indies on the Waitlist as to their availability to take the spot.  If you know outright you can't attend, please let us know and we'll remove you from the Waitlist.  (We're sorry but we cannot give out details regarding size of the Waitlist or entry position.)
+
+Alternatively you can also show at MAGFest even if you do not have a full-time MIVS booth area via "QuickPlay"!
+
+QuickPlay is an area at MIVS where tables are set aside for indies to show their game for a block of time.  As an indie, you'll be able to sign up for a 2 hour block of time, with possibly more blocks depending on availability.  We will provide a table, 2 chairs, and power.  You will need to provide your own equipment.  (WIFI/Network connections will not be available.)
+
+Signups for Quickplay will not happen online, they will only be available on-site at MAGFest in the MIVS area and will require you to have purchased a MAGFest badge.  Signups will be on a first come first serve basis, so we recommend visiting the MIVS area at your first convenience after picking up your MAGFest badge.
 
 {{ c.MIVS_EMAIL_SIGNATURE }}

--- a/mivs/templates/mivs_applications/confirm.html
+++ b/mivs/templates/mivs_applications/confirm.html
@@ -1,0 +1,49 @@
+{% extends "mivs_base.html" %}
+{% block body %}
+
+<h2>Please Confirm Your Acceptance into MIVS</h2>
+
+You have been accepted into the MAGFest Indie Videogame Showcase!  We need you to confirm that you are still interested
+and able to attend or let us know that you cannot, by clicking the appropriate button below.  As already explained, each
+studio receives {{ c.INDIE_BADGE_COMPS }} complementary badges for each game which is accepted into the showcase.  You
+have already left information for your presenters, so here is what will happen if you accept:
+
+<br/> <br/>
+
+<ul>
+{% for dev in developers %}
+    <li>
+        {{ dev.full_name }}
+        {% if dev.matching_attendee %}
+            is already in our registration database.
+            {% if dev.matching_attendee.group %}
+                Because this registration already belongs to a group, it will NOT be added to the group for this studio.
+            {% else %}
+                This registration will be moved into the group for this studio.
+            {% endif %}
+        {% elif dev.comped %}
+            will be registered for a complementary badge and will be prompted to fill out the rest of their information.
+        {% else %}
+            will be registered for an unpaid badge which will need to be paid later.
+        {% endif %}
+    </li>
+{% endfor %}
+{% if studio.unclaimed_badges %}
+    <li>
+        {{ studio.unclaimed_badges }} additional badge{{ studio.unclaimed_badges|pluralize }} will be registered,
+        which you can assign to whomever you wish.
+    </li>
+{% endif %}
+</ul>
+
+<br/>
+
+<form method="post" action="confirm">
+    {% csrf_token %}
+    <input type="submit" name="decision" value="Accept" />
+    <input type="submit" name="decision" value="Decline" />
+</form>
+
+<br/>
+
+{% endblock %}

--- a/mivs/templates/mivs_applications/index.html
+++ b/mivs/templates/mivs_applications/index.html
@@ -6,34 +6,46 @@ This is your application-in-progress for the MAGFest Indie Videogame Showcase fo
 <a href="studio">{{ studio.name }}</a>.  If you are not a member of {{ studio.name }} then please
 <a href="logout">log out</a>.
 
-<h3>Team Members</h3>
+{% if studio.group %}
+    <h3>Your Badges</h3>
 
-If your game is accepted, you will receive {{ c.INDIE_BADGE_COMPS }} complementary badges along with your booth space.
-One badge for yourself and one can be utilized by another team member.  Additional team members must purchase their badges.
-Transfer of badges between team members is prohibited.
+    You have been accepted into the showcase and confirmed that you are coming.  You may manage the badges in your
+    <a href="../preregistration/group_members?id={{ studio.group_id }}">group management page</a>.
+{% elif studio.comped_badges %}
+    <h3>Accept or Decline</h3>
 
-<table>
-{% for developer in studio.developers %}
-    <tr>
-        <td><ul><li></li></ul></td>
-        <td>{{ developer.full_name }}</td>
-        <td>[<a href="developer?id={{ developer.id }}">Edit</a>]</td>
-        <td>{{ developer.email }}</td>
-        <td>
-            {% if developer.primary_contact %}
-                <i>Primary Contact</i>
-            {% else %}
-                <form method="post" action="delete_developer">
-                    {% csrf_token %}
-                    <input type="hidden" name="id" value="{{ developer.id }}" />
-                    <input type="submit" value="Delete" />
-                </form>
-            {% endif %}
-        </td>
-    </tr>
-{% endfor %}
-</table>
-<a href="developer?id=None">Add a Presenter</a>
+    You have been accepted into the showcase, but we need you to confirm by {{ c.MIVS_CONFIRM_DEADLINE|datetime }} that you
+    are still interested and able to attend, which you may do by <a href="confirm">clicking here</a>.
+{% else %}
+    <h3>Team Members</h3>
+
+    If your game is accepted, you will receive {{ c.INDIE_BADGE_COMPS }} complementary badges along with your booth space.
+    One badge for yourself and one can be utilized by another team member.  Additional team members must purchase their badges.
+    Transfer of badges between team members is prohibited.
+
+    <table>
+    {% for developer in studio.developers %}
+        <tr>
+            <td><ul><li></li></ul></td>
+            <td>{{ developer.full_name }}</td>
+            <td>[<a href="developer?id={{ developer.id }}">Edit</a>]</td>
+            <td>{{ developer.email }}</td>
+            <td>
+                {% if developer.primary_contact %}
+                    <i>Primary Contact</i>
+                {% else %}
+                    <form method="post" action="delete_developer">
+                        {% csrf_token %}
+                        <input type="hidden" name="id" value="{{ developer.id }}" />
+                        <input type="submit" value="Delete" />
+                    </form>
+                {% endif %}
+            </td>
+        </tr>
+    {% endfor %}
+    </table>
+    <a href="developer?id=None">Add a Presenter</a>
+{% endif %}
 
 <h3>Games</h3>
 You have {% if c.BEFORE_ROUND_ONE_DEADLINE %}currently{% endif %} registered {{ studio.games|length }} game{{ studio.games|length|pluralize }}.
@@ -52,108 +64,112 @@ You have {% if c.BEFORE_ROUND_ONE_DEADLINE %}currently{% endif %} registered {{ 
         {% if not game.submitted %}[<a href="game?id={{ game.id }}">Edit</a>]{% endif %}
     </h4>
 
-    <div style="margin-left: 8ex">
-        <h4>Video Submission</h4>
-        {% if game.video_submitted %}
-            The video of your game has been submitted.
-        {% elif not game.video_submittable %}
-            Please include a link to a video using the Edit link above, no longer than 2 minutes, showing
-            at least 30 seconds of uninterrupted gameplay.  This video will be utilized by our judges to
-            determine if your game is accepted through Round 1 of judging.  If your game is accepted into
-            the showcase, this video link may be embedded on the MIVS web-page and/or other places that
-            MAGFest advertises the MIVS area.  You ust submit a video link before {{ c.ROUND_ONE_DEADLINE|datetime }}.
-        {% elif c.AFTER_ROUND_ONE_DEADLINE %}
-            You may no longer submit this game for consideration, as it is past the
-            {{ c.ROUND_ONE_DEADLINE|datetime }} deadline.
-        {% else %}
-            Once you're ready for our judges to look at the video link you've provided, you can submit it
-            to our panel of judges for consideration anytime until {{ c.ROUND_ONE_DEADLINE|datetime }}:
-            <form method="post" action="submit_video">
-                {% csrf_token %}
-                <input type="hidden" name="id" value="{{ game.id }}" />
-                <input type="submit" value="Submit Video for Consideration" />
-            </form>
-        {% endif %}
-
-        {% if c.ALLOW_GAME_SUBMISSION and game.status != c.VIDEO_DECLINED %}
-            <h4>Game Submission</h4>
-            {% if game.submitted %}
-                This game has been submitted.
-            {% elif c.AFTER_ROUND_TWO_DEADLINE %}
+    {% if game.status in c.FINAL_GAME_STATUSES %}
+        This game has been marked as {{ game.status_label }}.
+    {% else %}
+        <div style="margin-left: 8ex">
+            <h4>Video Submission</h4>
+            {% if game.video_submitted %}
+                The video of your game has been submitted.
+            {% elif not game.video_submittable %}
+                Please include a link to a video using the Edit link above, no longer than 2 minutes, showing
+                at least 30 seconds of uninterrupted gameplay.  This video will be utilized by our judges to
+                determine if your game is accepted through Round 1 of judging.  If your game is accepted into
+                the showcase, this video link may be embedded on the MIVS web-page and/or other places that
+                MAGFest advertises the MIVS area.  You ust submit a video link before {{ c.ROUND_ONE_DEADLINE|datetime }}.
+            {% elif c.AFTER_ROUND_ONE_DEADLINE %}
                 You may no longer submit this game for consideration, as it is past the
-                {{ c.ROUND_TWO_DEADLINE|datetime }} deadline.
-            {% elif not game.submittable %}
-                You cannot submit this game until the following criteria are met:
-                <ul>
-                {% for step in game.missing_steps %}
-                    <li>{{ step }}</li>
-                {% endfor %}
-                </ul>
+                {{ c.ROUND_ONE_DEADLINE|datetime }} deadline.
             {% else %}
-                You've met all the prerequisites to submit this game for consideration.  After submitting you may no longer
-                edit the game details unless the judges kick the game back to you and request edits.  You will still be able
-                to manage the game codes and screenshots after submitting.  Our judges will not look at your game until you
-                officially submit it by clicking this button:
-                <form method="post" action="submit_game" class="form-horizontal">
+                Once you're ready for our judges to look at the video link you've provided, you can submit it
+                to our panel of judges for consideration anytime until {{ c.ROUND_ONE_DEADLINE|datetime }}:
+                <form method="post" action="submit_video">
                     {% csrf_token %}
                     <input type="hidden" name="id" value="{{ game.id }}" />
-                    <input type="submit" value="Submit Game For Consideration" />
+                    <input type="submit" value="Submit Video for Consideration" />
                 </form>
             {% endif %}
-        {% endif %}
 
-        {% if game.link_to_game %}
-            <h4>Game Codes</h4>
-            {% if game.code_type == c.NO_CODE %}
-                You have indicated that once the judges access your game at the URL you've provided, they will not require any
-                kind of access code in order to play.
-                {% if not game.submitted %}
-                    If this is not correct, please <a href="game?id={{ game.id }}">edit your game information</a> to indicate
-                    what type of code is required.
-                {% endif %}
-            {% else %}
-                You have uploaded {{ game.codes|length }} code{{ game.codes|length|pluralize }}.
-                <table>
-                {% for code in game.codes %}
-                    <tr>
-                        <td><ul><li></li></ul></td>
-                        <td>{{ code.type_label }}</td>
-                        <td>{{ code.code }}</td>
-                        <td>
-                            <form method="post" action="delete_code">
-                            {% csrf_token %}
-                            <input type="hidden" name="id" value="{{ code.id }}" />
-                            <input type="submit" value="Delete" />
-                            </form>
-                        </td>
-                    </tr>
-                {% endfor %}
-                </table>
-                {% if not game.codes or not game.unlimited_code %}
-                    <a href="code?game_id={{ game.id }}">Add a code</a>
+            {% if c.ALLOW_GAME_SUBMISSION and game.status != c.VIDEO_DECLINED %}
+                <h4>Game Submission</h4>
+                {% if game.submitted %}
+                    This game has been submitted.
+                {% elif c.AFTER_ROUND_TWO_DEADLINE %}
+                    You may no longer submit this game for consideration, as it is past the
+                    {{ c.ROUND_TWO_DEADLINE|datetime }} deadline.
+                {% elif not game.submittable %}
+                    You cannot submit this game until the following criteria are met:
+                    <ul>
+                    {% for step in game.missing_steps %}
+                        <li>{{ step }}</li>
+                    {% endfor %}
+                    </ul>
+                {% else %}
+                    You've met all the prerequisites to submit this game for consideration.  After submitting you may no longer
+                    edit the game details unless the judges kick the game back to you and request edits.  You will still be able
+                    to manage the game codes and screenshots after submitting.  Our judges will not look at your game until you
+                    officially submit it by clicking this button:
+                    <form method="post" action="submit_game" class="form-horizontal">
+                        {% csrf_token %}
+                        <input type="hidden" name="id" value="{{ game.id }}" />
+                        <input type="submit" value="Submit Game For Consideration" />
+                    </form>
                 {% endif %}
             {% endif %}
-        {% endif %}
 
-        <h4>Screenshots</h4>
-        You have uploaded {{ game.screenshots|length }} screenshot{{ game.screenshots|length|pluralize }}
-        <table>
-        {% for screenshot in game.screenshots %}
-            <tr>
-                <td><ul><li></li></ul></td>
-                <td><a target="_blank" href="{{ screenshot.url }}">{{ screenshot.filename }}</a></td>
-                <td>{{ screenshot.description }}</td>
-                <td>
-                    <form method="post" action="delete_screenshot">
-                    {% csrf_token %}
-                    <input type="hidden" name="id" value="{{ screenshot.id }}" />
-                    <input type="submit" value="Delete" />
-                    </form>
-                </td>
-            </tr>
-        {% endfor %}
-        </table>
-        <a href="screenshot?game_id={{ game.id }}">Upload a screenshot</a>
+            {% if game.link_to_game %}
+                <h4>Game Codes</h4>
+                {% if game.code_type == c.NO_CODE %}
+                    You have indicated that once the judges access your game at the URL you've provided, they will not require any
+                    kind of access code in order to play.
+                    {% if not game.submitted %}
+                        If this is not correct, please <a href="game?id={{ game.id }}">edit your game information</a> to indicate
+                        what type of code is required.
+                    {% endif %}
+                {% else %}
+                    You have uploaded {{ game.codes|length }} code{{ game.codes|length|pluralize }}.
+                    <table>
+                    {% for code in game.codes %}
+                        <tr>
+                            <td><ul><li></li></ul></td>
+                            <td>{{ code.type_label }}</td>
+                            <td>{{ code.code }}</td>
+                            <td>
+                                <form method="post" action="delete_code">
+                                {% csrf_token %}
+                                <input type="hidden" name="id" value="{{ code.id }}" />
+                                <input type="submit" value="Delete" />
+                                </form>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </table>
+                    {% if not game.codes or not game.unlimited_code %}
+                        <a href="code?game_id={{ game.id }}">Add a code</a>
+                    {% endif %}
+                {% endif %}
+            {% endif %}
+
+            <h4>Screenshots</h4>
+            You have uploaded {{ game.screenshots|length }} screenshot{{ game.screenshots|length|pluralize }}
+            <table>
+            {% for screenshot in game.screenshots %}
+                <tr>
+                    <td><ul><li></li></ul></td>
+                    <td><a target="_blank" href="{{ screenshot.url }}">{{ screenshot.filename }}</a></td>
+                    <td>{{ screenshot.description }}</td>
+                    <td>
+                        <form method="post" action="delete_screenshot">
+                        {% csrf_token %}
+                        <input type="hidden" name="id" value="{{ screenshot.id }}" />
+                        <input type="submit" value="Delete" />
+                        </form>
+                    </td>
+                </tr>
+            {% endfor %}
+            </table>
+            <a href="screenshot?game_id={{ game.id }}">Upload a screenshot</a>
+        {% endif %}
     </div>
 {% endfor %}
 


### PR DESCRIPTION
I also added the text of the accept/decline/waitlist emails, plus a reminder email for people accepted who still haven't accepted/declined as of 2 days before the deadline.

This PR involves a small database change, which I performed manually on the staging and production servers:

```sql
ALTER TABLE indie_studio ADD COLUMN group_id UUID NULL;
ALTER TABLE indie_studio ADD CONSTRAINT indie_studio_group_id_fkey FOREIGN KEY (group_id) REFERENCES "group" (id);
```