### PR TITLE
Fixed bug with "confirmed" status

### DIFF
--- a/mivs/templates/mivs_admin/index.html
+++ b/mivs/templates/mivs_admin/index.html
@@ -50,7 +50,7 @@
     <tr>
         <td>{{ game.title }}</td>
         <td>
-            {% if game.studio.group_id %}
+            {% if game.status == c.ACCEPTED and game.studio.group_id %}
                 confirmed
             {% else %}
                 {{ game.status_label }}


### PR DESCRIPTION
There's a bug in the display code for game statuses.  I have an if-statement that currently works like

```
if game.studio.confirmed
then -> show "confirmed"
else -> show the status label
```

I didn't think about the case where a studio had one game accepted and another game not accepted.  I'll need to change it to be like:

```
if game.accepted and game.studio.confirmed
then -> show "confirmed"
else -> show the status label
```