### PR TITLE
fixed bug in confirm reminder email

### DIFF
--- a/mivs/automated_emails.py
+++ b/mivs/automated_emails.py
@@ -40,7 +40,7 @@ MIVSEmail(IndieGame, 'Your MIVS application has been waitlisted', 'game_waitlist
           lambda game: game.status == c.WAITLISTED)
 
 MIVSEmail(IndieGame, 'Last chance to accept your MIVS booth', 'game_accept_reminder.txt',
-          lambda game: game.status == c.ACCEPTED and days_before(2, c.MIVS_CONFIRM_DEADLINE))
+          lambda game: game.status == c.ACCEPTED and not game.studio.group_id and days_before(2, c.MIVS_CONFIRM_DEADLINE))
 
 MIVSEmail(IndieGame, 'MIVS judging is wrapping up', 'round_two_closing.txt',
           lambda game: game.submitted and days_before(14, c.JUDGING_DEADLINE))


### PR DESCRIPTION
I accidentally configured the "you haven't confirmed your booth yet" email to go out to ALL accepted games instead of only other games that hasn't confirmed yet.  This fixes that.