### PR TITLE
allow admins to add new studios+games after the round1 deadline

### DIFF
--- a/mivs/model_checks.py
+++ b/mivs/model_checks.py
@@ -18,7 +18,7 @@ IndieStudio.required = [('name', 'Studio Name')]
 
 @validation.IndieStudio
 def new_studio_deadline(studio):
-    if studio.is_new and c.AFTER_ROUND_ONE_DEADLINE and c.INDIE_ADMIN not in AdminAccount.access_set():
+    if studio.is_new and c.AFTER_ROUND_ONE_DEADLINE and c.HAS_INDIE_ADMIN_ACCESS:
         return 'Sorry, but the round one deadline has already passed, so no new studios may be registered'
 
 
@@ -61,7 +61,7 @@ IndieGame.required = [
 
 @validation.IndieGame
 def new_game_deadline(game):
-    if game.is_new and c.AFTER_ROUND_ONE_DEADLINE and c.INDIE_ADMIN not in AdminAccount.access_set():
+    if game.is_new and c.AFTER_ROUND_ONE_DEADLINE and c.HAS_INDIE_ADMIN_ACCESS:
         return 'Sorry, but the round one deadline has already passed, so no new games may be registered'
 
 

--- a/mivs/model_checks.py
+++ b/mivs/model_checks.py
@@ -18,7 +18,7 @@ IndieStudio.required = [('name', 'Studio Name')]
 
 @validation.IndieStudio
 def new_studio_deadline(studio):
-    if studio.is_new and c.AFTER_ROUND_ONE_DEADLINE:
+    if studio.is_new and c.AFTER_ROUND_ONE_DEADLINE and c.INDIE_ADMIN not in AdminAccount.access_set():
         return 'Sorry, but the round one deadline has already passed, so no new studios may be registered'
 
 
@@ -61,7 +61,7 @@ IndieGame.required = [
 
 @validation.IndieGame
 def new_game_deadline(game):
-    if game.is_new and c.AFTER_ROUND_ONE_DEADLINE:
+    if game.is_new and c.AFTER_ROUND_ONE_DEADLINE and c.INDIE_ADMIN not in AdminAccount.access_set():
         return 'Sorry, but the round one deadline has already passed, so no new games may be registered'
 
 

--- a/mivs/site_sections/mivs_applications.py
+++ b/mivs/site_sections/mivs_applications.py
@@ -1,12 +1,8 @@
 from mivs import *
 
 
-def is_mivs_admin():
-    return c.INDIE_ADMIN in AdminAccount.access_set()
-
-
 def allowed_to_submit_round1():
-    return c.BEFORE_ROUND_ONE_DEADLINE or is_mivs_admin()
+    return c.BEFORE_ROUND_ONE_DEADLINE or c.HAS_INDIE_ADMIN_ACCESS
 
 
 @all_renderable()
@@ -16,7 +12,6 @@ class Root:
             'message': message,
             'studio': session.logged_in_studio(),
             'allowed_to_add_game': allowed_to_submit_round1(),
-            'is_mivs_admin': is_mivs_admin(),
         }
 
     def logout(self):
@@ -62,7 +57,6 @@ class Root:
             'studio': studio,
             'developer': developer,
             'allowed_to_submit': allowed_to_submit,
-            'is_mivs_admin': is_mivs_admin(),
         }
 
     def game(self, session, message='', **params):

--- a/mivs/templates/mivs_applications/index.html
+++ b/mivs/templates/mivs_applications/index.html
@@ -55,7 +55,7 @@ You have {% if c.BEFORE_ROUND_ONE_DEADLINE %}currently{% endif %} registered {{ 
 {% endif %}
 
 {% if allowed_to_add_game %}
-    {% if is_mivs_admin %}
+    {% if c.HAS_INDIE_ADMIN_ACCESS %}
         <br/><br/><b><font color="red">
         ADMIN NOTE: Because you are logged in as a MIVS admin, you can still use this form to manually create a
         game. For non-admin users, they will not be able to do this.
@@ -83,7 +83,7 @@ You have {% if c.BEFORE_ROUND_ONE_DEADLINE %}currently{% endif %} registered {{ 
                 determine if your game is accepted through Round 1 of judging.  If your game is accepted into
                 the showcase, this video link may be embedded on the MIVS web-page and/or other places that
                 MAGFest advertises the MIVS area.  You must submit a video link before {{ c.ROUND_ONE_DEADLINE|datetime }}.
-            {% elif c.AFTER_ROUND_ONE_DEADLINE and not is_mivs_admin %}
+            {% elif c.AFTER_ROUND_ONE_DEADLINE and not c.HAS_INDIE_ADMIN_ACCESS %}
                 You may no longer submit this game for consideration, as it is past the
                 {{ c.ROUND_ONE_DEADLINE|datetime }} deadline.
             {% else %}

--- a/mivs/templates/mivs_applications/index.html
+++ b/mivs/templates/mivs_applications/index.html
@@ -54,7 +54,13 @@ You have {% if c.BEFORE_ROUND_ONE_DEADLINE %}currently{% endif %} registered {{ 
     after which no more games may be submitted.
 {% endif %}
 
-{% if c.BEFORE_ROUND_ONE_DEADLINE %}
+{% if allowed_to_add_game %}
+    {% if is_mivs_admin %}
+        <br/><br/><b><font color="red">
+        ADMIN NOTE: Because you are logged in as a MIVS admin, you can still use this form to manually create a
+        game. For non-admin users, they will not be able to do this.
+        </font></b>
+    {% endif %}
     <br/><a href="game">Add a game</a>
 {% endif %}
 
@@ -77,7 +83,7 @@ You have {% if c.BEFORE_ROUND_ONE_DEADLINE %}currently{% endif %} registered {{ 
                 determine if your game is accepted through Round 1 of judging.  If your game is accepted into
                 the showcase, this video link may be embedded on the MIVS web-page and/or other places that
                 MAGFest advertises the MIVS area.  You must submit a video link before {{ c.ROUND_ONE_DEADLINE|datetime }}.
-            {% elif c.AFTER_ROUND_ONE_DEADLINE %}
+            {% elif c.AFTER_ROUND_ONE_DEADLINE and not is_mivs_admin %}
                 You may no longer submit this game for consideration, as it is past the
                 {{ c.ROUND_ONE_DEADLINE|datetime }} deadline.
             {% else %}

--- a/mivs/templates/mivs_applications/studio.html
+++ b/mivs/templates/mivs_applications/studio.html
@@ -3,10 +3,17 @@
 
 {% if studio.is_new %}
     <h2>MAGFest Indie Videogame Showcase</h2>
-    {% if c.BEFORE_ROUND_ONE_DEADLINE %}
+    {% if c.BEFORE_ROUND_ONE_DEADLINE or is_mivs_admin %}
         Please fill out information about your studio.  You will then be prompted to enter information about the game(s)
         you are submitting.  If you've already submitted an application, you can use the link provided in the email we've
         sent you which you can use to continue an existing application.
+
+        {% if is_mivs_admin %}
+            <br/><br/><b><font color="red">
+            ADMIN NOTE: Because you are logged in as a MIVS admin, you can still use this form to manually enter a new
+            studio. For non-admin users, they will see a message about the deadline being passed.
+            </font></b>
+        {% endif %}
     {% else %}
         The round one deadline has passed, so no new studios may be registered for this year's showcase.  If you would
         like to continue an existing registration, you may do so using the link sent to you in the email you received
@@ -16,7 +23,7 @@
     <h2>Edit Your Studio Information</h2>
 {% endif %}
 
-{% if c.BEFORE_ROUND_ONE_DEADLINE or not studio.is_new %}
+{% if allowed_to_submit %}
     <form method="post" action="studio" class="form-horizontal" role="form">
         {% csrf_token %}
 

--- a/mivs/templates/mivs_applications/studio.html
+++ b/mivs/templates/mivs_applications/studio.html
@@ -3,12 +3,12 @@
 
 {% if studio.is_new %}
     <h2>MAGFest Indie Videogame Showcase</h2>
-    {% if c.BEFORE_ROUND_ONE_DEADLINE or is_mivs_admin %}
+    {% if c.BEFORE_ROUND_ONE_DEADLINE or c.HAS_INDIE_ADMIN_ACCESS %}
         Please fill out information about your studio.  You will then be prompted to enter information about the game(s)
         you are submitting.  If you've already submitted an application, you can use the link provided in the email we've
         sent you which you can use to continue an existing application.
 
-        {% if is_mivs_admin %}
+        {% if c.HAS_INDIE_ADMIN_ACCESS %}
             <br/><br/><b><font color="red">
             ADMIN NOTE: Because you are logged in as a MIVS admin, you can still use this form to manually enter a new
             studio. For non-admin users, they will see a message about the deadline being passed.


### PR DESCRIPTION
MIVS crew needed the ability to add a game for a submitter with persistent technical issues.

Even after round1 is finished, allow MIVS admins to submit games and studios if they so desire.

other note: security: ```studio()``` page could accept POST data because the only safeguards for whether the deadline had passed were in the page itself.  thus there was no enforcement of this in the business logic, so I also added that.

this could probably use a decent set of eyes on it before merging.  I tested locally, seems to work well.