### PR TITLE
Allow MIVS admins to edit games after submission

### DIFF
--- a/mivs/templates/mivs_applications/index.html
+++ b/mivs/templates/mivs_applications/index.html
@@ -67,7 +67,7 @@ You have {% if c.BEFORE_ROUND_ONE_DEADLINE %}currently{% endif %} registered {{ 
 {% for game in studio.games %}
     <h4>
         {{ game.title }}
-        {% if not game.submitted %}[<a href="game?id={{ game.id }}">Edit</a>]{% endif %}
+        {% if c.HAS_INDIE_ADMIN_ACCESS or not game.submitted %}[<a href="game?id={{ game.id }}">Edit</a>]{% endif %}
     </h4>
 
     {% if game.status in c.FINAL_GAME_STATUSES %}


### PR DESCRIPTION
We sometimes need to change a game submission after the developer has indicated it's complete. This lets MIVS admins go into a game's edit page regardless of its submission status.

I don't know quite enough about the MIVS workflow to test this on my local server but it should be straightforward. Also, we want MIVS approval for this change - I've emailed them about it already.