### PR TITLE
Add automated email for games with broken video links

### DIFF
--- a/mivs/automated_emails.py
+++ b/mivs/automated_emails.py
@@ -35,6 +35,10 @@ MIVSEmail(IndieStudio, 'MIVS - Wat no video?', 'videoless_studio.txt',
           ident='mivs_missing_video_inquiry',
           when=days_before(7, c.ROUND_ONE_DEADLINE))
 
+MIVSEmail(IndieGame, 'MIVS: Your Submitted Video Is Broken', 'video_broken.txt',
+          lambda game: game.video_broken,
+          ident='mivs_video_broken')
+
 MIVSEmail(IndieGame, 'Last chance to submit your game to MIVS', 'round_two_reminder.txt',
           lambda game: game.status == c.JUDGING and not game.submitted,
           ident='mivs_game_submission_reminder',

--- a/mivs/models.py
+++ b/mivs/models.py
@@ -216,6 +216,12 @@ class IndieGame(MagModel, ReviewMixin):
         return steps
 
     @property
+    def video_broken(self):
+        for r in self.reviews:
+            if r.video_status == c.BAD_LINK:
+                return True
+
+    @property
     def unlimited_code(self):
         for code in self.codes:
             if code.unlimited_use:

--- a/mivs/templates/emails/game_video_submitted.txt
+++ b/mivs/templates/emails/game_video_submitted.txt
@@ -4,7 +4,7 @@ Your game ({{ game.title }}) has been submitted for review into the MAGFest Indi
 
 During the week after Round 1 closes, we'll be reviewing your video.  Based on the judging of the video content, we'll inform you {{ c.VIDEO_RESPONSE_EXPECTED }} as to whether or not your game is accepted into Round 2, where a demo of the game itself will be judged.
 
-All details, including Round 2, will be available on the FAQ at http://magfest.org/mivsfaq.  That page is updated as we progress through the judging, so be sure to check it for new content.
+All details, including Round 2, will be available on the FAQ at http://super.magfest.org/mivsfaq/.  That page is updated as we progress through the judging, so be sure to check it for new content.
 
 As always, you can continue managing your application at any time at {{ c.URL_BASE }}/mivs_applications/continue_app?id={{ game.studio.id }}
 

--- a/mivs/templates/emails/video_broken.txt
+++ b/mivs/templates/emails/video_broken.txt
@@ -1,0 +1,7 @@
+{{ game.studio.primary_contact.first_name }},
+
+One of the judges for the MAGFest Indie Videogame Showcase (MIVS) has tried to review your video for Round 1, but could not watch it due to a broken link! Please check your link and correct the problem within 24 hours. Bad video links that are not fixed in time will be declined.
+
+If you need to update the video link on your application, you can do so at {{ c.URL_BASE }}/mivs_applications/continue_app?id={{ game.studio.id }}
+
+{{ c.MIVS_EMAIL_SIGNATURE }}


### PR DESCRIPTION
Fixes https://github.com/magfest/mivs/issues/9. The actual declining is left up to admins' discretion, but the system now warns studios that their video link is broken.