### PR TITLE
Uses studio.status_label instead of c.STUDIO_STATUS[studio.status] in studio list

### DIFF
--- a/mivs/templates/mivs_admin/studios.html
+++ b/mivs/templates/mivs_admin/studios.html
@@ -42,7 +42,7 @@
       {{ studio.website|url_to_link(is_relative=False) }}
     </td>
     <td>
-      {{ c.STUDIO_STATUS[studio.status] }}
+      {{ studio.status_label }}
     </td>
   </tr>
 {% endfor %}


### PR DESCRIPTION
Per pull request feedback here: https://github.com/magfest/mivs/pull/98/files#r137939143