### PR TITLE
Send emails to multiple 'primary contacts'

### DIFF
--- a/mivs/models.py
+++ b/mivs/models.py
@@ -118,7 +118,7 @@ class IndieStudio(MagModel):
 
     @property
     def email(self):
-        return self.primary_contact.email
+        return [dev.email for dev in self.developers if dev.primary_contact]
 
     @property
     def primary_contact(self):

--- a/mivs/site_sections/mivs_admin.py
+++ b/mivs/site_sections/mivs_admin.py
@@ -44,7 +44,7 @@ class Root:
                 game.studio.name,
                 '{}/mivs_applications/continue_app?id={}'.format(c.URL_BASE, game.studio.id),
                 game.studio.primary_contact.full_name,
-                game.email,
+                game.studio.primary_contact.email,
                 ' / '.join(game.genres_labels),
                 game.brief_description,
                 game.description,


### PR DESCRIPTION
The system was randomly selecting one of the contacts in a studio to send all emails to, causing confusion. Now anyone who's marked as receiving emails will get them, though they'll still be addressed to only one person.