### PR TITLE
Allow judges to update their own preferences

### DIFF
--- a/mivs/site_sections/mivs_admin.py
+++ b/mivs/site_sections/mivs_admin.py
@@ -65,7 +65,7 @@ class Root:
             ] + [str(score) for score in game.scores])
 
     def create_judge(self, session, message='', first_name='', last_name='', email='', **params):
-        judge = session.indie_judge(params, checkgroups=['genres'])
+        judge = session.indie_judge(params, checkgroups=['genres', 'platforms'])
         if cherrypy.request.method == 'POST':
             message = check(judge)
             if not message and not first_name or not last_name or not email:
@@ -110,7 +110,7 @@ class Root:
         }
 
     def edit_judge(self, session, message='', **params):
-        judge = session.indie_judge(params)
+        judge = session.indie_judge(params, checkgroups=['genres', 'platforms'])
         if cherrypy.request.method == 'POST':
             message = check(judge)
             if not message:

--- a/mivs/site_sections/mivs_judging.py
+++ b/mivs/site_sections/mivs_judging.py
@@ -3,10 +3,16 @@ from mivs import *
 
 @all_renderable(c.INDIE_JUDGE)
 class Root:
-    def index(self, session, message=''):
+    def index(self, session, message='', **params):
+        judge = session.indie_judge(params, checkgroups=['genres', 'platforms']) if 'id' in params else session.logged_in_judge()
+        if cherrypy.request.method == 'POST':
+            message = check(judge)
+            if not message:
+                raise HTTPRedirect('index?message={}', 'Preferences updated')
+
         return {
             'message': message,
-            'judge': session.logged_in_judge()
+            'judge': judge
         }
 
     def studio(self, session, message='', **params):

--- a/mivs/templates/emails/judge_intro.txt
+++ b/mivs/templates/emails/judge_intro.txt
@@ -1,6 +1,6 @@
 Hello {{ judge.attendee.first_name }},
 
-If you're receiving this, you've been selected to be a Judge for this year's MAGFest Indie Video Game Showcase. (MIVS) You should have already received an email with login information for your judging account.  
+If you're receiving this, you've been selected to be a Judge for this year's MAGFest Indie Video Game Showcase. (MIVS) You should have already received an email with login information for your judging account. If you haven't already done so, please log in at {{ c.URL_BASE }}/mivs_judging/index and tell us what genres you prefer to play and what platforms you own.
 
 For helping us judge the entries to be shown for this year, we are happy to give you a free pass to MAGFest.  If you feel at any time that you are unable to complete your duties as a judge, everything will be fine as long as you let us known as soon as possible.
 

--- a/mivs/templates/mivs_judging/index.html
+++ b/mivs/templates/mivs_judging/index.html
@@ -1,6 +1,36 @@
 {% extends "mivs_base.html" %}
 {% block body %}
 
+<h2>Your Preferences</h2>
+  In order to help us match you with the right kinds of games, please tell us what genres you prefer to play and what
+  platforms you own.
+  <form method="post" action="index" role="form" class="form-horizontal">
+    <input type="hidden" name="id" value="{{ judge.id }}" />
+    {{ csrf_token() }}
+    <div class="form-group">
+      <label class="col-sm-3 control-label">Genres</label>
+      <div class="col-sm-6">
+        {{ macros.checkgroup(judge, 'genres') }}
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label class="col-sm-3 control-label">Platforms Owned</label>
+      <div class="col-sm-6">
+        {{ macros.checkgroup(judge, 'platforms') }}
+      </div>
+      <div class="clearfix"></div>
+      <div class="col-sm-6 col-sm-offset-3">
+        <input id="platforms-other" class="form-control" type="text" name="platforms_text" value="{{ judge.platforms_text }}" placeholder="Other platform(s)"/>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-6 col-sm-offset-2">
+        <button type="submit" class="btn btn-primary">Update Preferences</button>
+      </div>
+    </div>
+  </form>
+
 <h2>Your MIVS Games For Review</h2>
 
 You ({{ judge.full_name }}) have been assigned {{ judge.reviews|length }} games for review


### PR DESCRIPTION
Adds genres and platforms to judges' home page so they can tell us directly which genres and platforms they like and have, respectively. Also edits the introduction email to give them the link to log in.

Fixes https://github.com/magfest/mivs/issues/105.