### PR TITLE
Add variable confirmation deadline for studios

### DIFF
--- a/alembic/versions/62f319b9a3b6_add_accepted_date_to_indie_games.py
+++ b/alembic/versions/62f319b9a3b6_add_accepted_date_to_indie_games.py
@@ -1,0 +1,64 @@
+"""Add accepted date to indie games
+
+Revision ID: 62f319b9a3b6
+Revises: fdaa0d889a48
+Create Date: 2017-10-11 22:11:05.255045
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '62f319b9a3b6'
+down_revision = 'fdaa0d889a48'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+import sideboard.lib.sa
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    if is_sqlite:
+        with op.batch_alter_table('indie_game', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+            batch_op.add_column(sa.Column('accepted', sideboard.lib.sa.UTCDateTime(), nullable=True))
+    else:
+        op.add_column('indie_game', sa.Column('accepted', sideboard.lib.sa.UTCDateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('indie_game', 'accepted')

--- a/mivs/automated_emails.py
+++ b/mivs/automated_emails.py
@@ -65,7 +65,8 @@ MIVSEmail(IndieGame, 'Your MIVS application has been waitlisted', 'game_waitlist
           ident='mivs_game_waitlisted')
 
 MIVSEmail(IndieGame, 'Last chance to accept your MIVS booth', 'game_accept_reminder.txt',
-          lambda game: game.status == c.ACCEPTED and not game.confirmed, when=days_before(2, c.MIVS_CONFIRM_DEADLINE),
+          lambda game: game.status == c.ACCEPTED and not game.confirmed
+                       and (localized_now() - timedelta(days=2)) > game.studio.confirm_deadline,
           ident='mivs_accept_booth_reminder')
 
 MIVSEmail(IndieGame, 'MIVS December Updates: Hotels and Magfest Versus!', 'december_updates.txt',

--- a/mivs/configspec.ini
+++ b/mivs/configspec.ini
@@ -51,13 +51,15 @@ skip_mivs_url_validation = boolean(default=True)
 # computer time disagree. This grace period, defined in minutes, is added to all submission deadlines on the backend.
 submission_grace_period = integer(default=10)
 
+# Studios have a certain number of days after their acceptance to confirm they will show at MIVS.
+# Their custom confirmation deadline is calculated using this config option.
+mivs_confirm_deadline = integer(default=14)
+
 [dates]
 round_one_deadline = string(default="2015-10-31")
 round_two_deadline = string(default="2015-11-30")
 judging_deadline = string(default="2016-01-03")
 round_two_complete = string(default="2016-01-09")
-mivs_confirm_deadline = string(default="2016-01-15")
-
 
 [enums]
 

--- a/mivs/site_sections/mivs_admin.py
+++ b/mivs/site_sections/mivs_admin.py
@@ -35,7 +35,8 @@ class Root:
             'Genres', 'Brief Description', 'Long Description', 'How to Play',
             'Link to Video', 'Link to Game', 'Game Link Password',
             'Game Requires Codes?', 'Code Instructions', 'Build Status', 'Build Notes',
-            'Video Submitted', 'Game Submitted', 'Current Status', 'Registered',
+            'Video Submitted', 'Game Submitted', 'Current Status',
+            'Registered', 'Accepted', 'Confirmation Deadline',
             'Screenshots', 'Average Score', 'Individual Scores'
         ])
         for game in session.indie_games():
@@ -60,6 +61,8 @@ class Root:
                 'submitted' if game.submitted else 'not submitted',
                 'accepted and confirmed' if game.confirmed else game.status_label,
                 game.registered.strftime('%Y-%m-%d'),
+                'n/a' if not game.accepted else game.accepted.strftime('%Y-%m-%d'),
+                'n/a' if not game.accepted else game.studio.confirm_deadline.strftime('%Y-%m-%d'),
                 '\n'.join(c.URL_BASE + screenshot.url.lstrip('.') for screenshot in game.screenshots),
                 str(game.average_score)
             ] + [str(score) for score in game.scores])

--- a/mivs/site_sections/mivs_applications.py
+++ b/mivs/site_sections/mivs_applications.py
@@ -168,6 +168,8 @@ class Root:
             raise HTTPRedirect('index?message={}', 'You did not have any games accepted')
         elif studio.group:
             raise HTTPRedirect('index?message={}', 'Your group has already been created')
+        elif studio.after_confirm_deadline:
+            raise HTTPRedirect('index?message={}', 'The deadline for confirming your acceptance has passed.')
 
         has_leader = False
         badges_remaining = studio.comped_badges

--- a/mivs/templates/emails/game_accept_reminder.txt
+++ b/mivs/templates/emails/game_accept_reminder.txt
@@ -1,9 +1,9 @@
 {{ game.studio.primary_contact.first_name }},
 
-Congratulations again for your game submission ({{ game.title }}) being accepted into the 2016 MAGFest Indie Videogame Showcase (MIVS).
+Congratulations again for your game submission ({{ game.title }}) being accepted into the {{ c.ESCHATON.year }} MAGFest Indie Videogame Showcase (MIVS).
 
 You still haven't told us whether or not you accept the offer of a table in the showcase, which you may do at {{ c.URL_BASE }}/mivs_applications/continue_app?id={{ game.studio.id }}
 
-You must accept or decline the space by {{ c.MIVS_CONFIRM_DEADLINE|datetime_local }}.  Telling us you aren't able to meet the requirements leaves your team on good terms with the MIVS staff; failing to show or not meeting the requirements will be taken into consideration for future events.
+You must accept or decline the space by {{ game.studio.confirm_deadline|datetime_local }}. Telling us you aren't able to meet the requirements leaves your team on good terms with the MIVS staff; failing to show or not meeting the requirements will be taken into consideration for future events.
 
 {{ c.MIVS_EMAIL_SIGNATURE }}

--- a/mivs/templates/emails/game_accepted.txt
+++ b/mivs/templates/emails/game_accepted.txt
@@ -1,12 +1,12 @@
 {{ game.studio.primary_contact.first_name }},
 
-Congratulations!  Your game submission ({{ game.title }}) for the 2017 MAGFest Indie Videogame Showcase (MIVS) is one of the 57 that have been accepted into the showcase.
+Congratulations!  Your game submission ({{ game.title }}) for the {{ c.ESCHATON.year }} MAGFest Indie Videogame Showcase (MIVS) is one of the 57 that have been accepted into the showcase.
 
 *** YOU NEED TO CONFIRM YOUR ACCEPTANCE! ***
 
 Please confirm that you are coming OR let us know that you cannot make it after all at {{ c.URL_BASE }}/mivs_applications/continue_app?id={{ game.studio.id }}
 
-You have until 11:59 on November 16, 2016 to confirm (or decline).
+You have until {{ game.studio.confirm_deadline|datetime_local }} to confirm (or decline).
 
 We'd much rather you explicitly decline than to just fade, as being prompt helps us to move indies who are on the waitlist into the showcase.
 


### PR DESCRIPTION
Fixes https://github.com/magfest/mivs/issues/32 by first adding an 'accepted' column to indie games so we can track when they're accepted, then taking the first accepted date and calculating a custom 'confirmation deadline' for the studio based on that. Changes the emails to reflect the new date. Also fixes https://github.com/magfest/mivs/issues/36 by booting out any studio attempting to go to the confirmation page after their deadline has passed.