### PR TITLE
Make game fields date-based

### DIFF
--- a/mivs/configspec.ini
+++ b/mivs/configspec.ini
@@ -1,9 +1,3 @@
-
-# MIVS has two rounds of applications, one where we submit video and one where
-# video is submitted and one where the game itself is submitted.  For the first
-# round we do NOT want to show the fields involving the actual game.
-allow_game_submission = boolean(default=False)
-
 # Email address which will send emails
 mivs_email = string(default="MAGFest Indie Videogame Showcase <mivs@magfest.org>")
 
@@ -57,6 +51,7 @@ mivs_confirm_deadline = integer(default=14)
 
 [dates]
 round_one_deadline = string(default="2015-10-31")
+round_two_start = string(default="2015-11-01")
 round_two_deadline = string(default="2015-11-30")
 judging_deadline = string(default="2016-01-03")
 round_two_complete = string(default="2016-01-09")

--- a/mivs/templates/mivs_applications/game.html
+++ b/mivs/templates/mivs_applications/game.html
@@ -102,7 +102,7 @@
       </div>
     </div>
 
-    {% if c.ALLOW_GAME_SUBMISSION and game.status != c.VIDEO_DECLINED %}
+    {% if c.AFTER_ROUND_TWO_START and game.status != c.VIDEO_DECLINED %}
       {% include 'mivs_applications/game_build_info.html' %}
     {% endif %}
 

--- a/mivs/templates/mivs_applications/index.html
+++ b/mivs/templates/mivs_applications/index.html
@@ -148,7 +148,7 @@
           </form>
         {% endif %}
 
-        {% if c.ALLOW_GAME_SUBMISSION and game.status != c.VIDEO_DECLINED %}
+        {% if c.AFTER_ROUND_TWO_START and game.status != c.VIDEO_DECLINED %}
           <h4>Game Submission</h4>
           {% if game.submitted %}
             This game has been submitted.

--- a/mivs/templates/mivs_judging/index.html
+++ b/mivs/templates/mivs_judging/index.html
@@ -42,7 +42,7 @@ and {{ judge.game_reviews|length }} have had the actual game reviewed.
     <tr>
         <th>Game</th>
         <th>Studio</th>
-        {% if c.ALLOW_GAME_SUBMISSION %}
+        {% if c.AFTER_ROUND_TWO_START %}
             <th>Game Review Status</th>
             <th>Your Score</th>
         {% else %}
@@ -52,11 +52,11 @@ and {{ judge.game_reviews|length }} have had the actual game reviewed.
 </thead>
 <tbody>
 {% for review in judge.reviews %}
-    {% if not c.ALLOW_GAME_SUBMISSION or review.game.status != c.VIDEO_DECLINED %}
+    {% if not c.AFTER_ROUND_TWO_START or review.game.status != c.VIDEO_DECLINED %}
         <tr>
             <td>{{ review.game.title }}</td>
             <td><a href="studio?id={{ review.game.studio.id }}">{{ review.game.studio.name }}</a></td>
-            {% if c.ALLOW_GAME_SUBMISSION %}
+            {% if c.AFTER_ROUND_TWO_START %}
                 <td><a href="game_review?id={{ review.id }}">{{ review.game_status_label }}</a></td>
                 <td>{{ review.game_score|default("not reviewed yet") }}</td>
             {% else %}


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2066 in the long term by tying the game submission fields to a date rather than a boolean setting. Having it on a boolean was confusing everyone.