### PR TITLE
Add automated email to send judge reviews to studios

### DIFF
--- a/alembic/versions/c2c484e647ec_add_send_to_studio_column_to_reviews.py
+++ b/alembic/versions/c2c484e647ec_add_send_to_studio_column_to_reviews.py
@@ -1,0 +1,63 @@
+"""Add 'send to studio' column to reviews
+
+Revision ID: c2c484e647ec
+Revises: 62f319b9a3b6
+Create Date: 2017-10-13 04:18:59.337221
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'c2c484e647ec'
+down_revision = '62f319b9a3b6'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    if is_sqlite:
+        with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+            batch_op.add_column(sa.Column('send_to_studio', sa.Boolean(), server_default='False', nullable=False))
+    else:
+        op.add_column('indie_game_review', sa.Column('send_to_studio', sa.Boolean(), server_default='False', nullable=False))
+
+
+def downgrade():
+    op.drop_column('indie_game_review', 'send_to_studio')

--- a/alembic/versions/c2c484e647ec_add_send_to_studio_column_to_reviews.py
+++ b/alembic/versions/c2c484e647ec_add_send_to_studio_column_to_reviews.py
@@ -1,7 +1,7 @@
 """Add 'send to studio' column to reviews
 
 Revision ID: c2c484e647ec
-Revises: 62f319b9a3b6
+Revises: a186029770bb
 Create Date: 2017-10-13 04:18:59.337221
 
 """
@@ -9,7 +9,7 @@ Create Date: 2017-10-13 04:18:59.337221
 
 # revision identifiers, used by Alembic.
 revision = 'c2c484e647ec'
-down_revision = '62f319b9a3b6'
+down_revision = 'a186029770bb'
 branch_labels = None
 depends_on = None
 

--- a/mivs/automated_emails.py
+++ b/mivs/automated_emails.py
@@ -77,6 +77,10 @@ MIVSEmail(IndieGame, 'REQUIRED: Pre-flight for MIVS due by midnight, January 2nd
           lambda game: game.confirmed,
           ident='mivs_game_preflight_reminder')
 
+MIVSEmail(IndieGame, 'Summary of judging results for your game', 'reviews_summary.html',
+          lambda game: game.status in c.FINAL_GAME_STATUSES and game.reviews_to_email,
+          ident='mivs_reviews_summary')
+
 MIVSEmail(IndieGame, 'MIVS judging is wrapping up', 'round_two_closing.txt',
           lambda game: game.submitted, when=days_before(14, c.JUDGING_DEADLINE),
           ident='mivs_round_two_closing')

--- a/mivs/models.py
+++ b/mivs/models.py
@@ -213,6 +213,10 @@ class IndieGame(MagModel, ReviewMixin):
         return self.studio.email
 
     @property
+    def reviews_to_email(self):
+        return [review for review in self.reviews if review.send_to_studio]
+
+    @property
     def video_href(self):
         return href(self.link_to_video)
 
@@ -317,6 +321,7 @@ class IndieGameReview(MagModel):
     game_review        = Column(UnicodeText)
     developer_response = Column(UnicodeText)
     staff_notes        = Column(UnicodeText)
+    send_to_studio     = Column(Boolean, default=False)
 
     __table_args__ = (UniqueConstraint('game_id', 'judge_id', name='review_game_judge_uniq'),)
 

--- a/mivs/site_sections/mivs_admin.py
+++ b/mivs/site_sections/mivs_admin.py
@@ -175,8 +175,11 @@ class Root:
     def video_results(self, session, id):
         return {'game': session.indie_game(id)}
 
-    def game_results(self, session, id):
-        return {'game': session.indie_game(id)}
+    def game_results(self, session, id, message=''):
+        return {
+            'game': session.indie_game(id),
+            'message': message
+        }
 
     @csrf_protected
     def mark_verdict(self, session, id, status):
@@ -186,6 +189,17 @@ class Root:
             game = session.indie_game(id)
             game.status = int(status)
             raise HTTPRedirect('index?message={}{}{}', game.title, ' has been marked as ', game.status_label)
+
+    @csrf_protected
+    def send_reviews(self, session, game_id, review_id=None):
+        game = session.indie_game(id=game_id)
+        for review in game.reviews:
+            if review.id in listify(review_id):
+                review.send_to_studio = True
+            elif review.send_to_studio:
+                review.send_to_studio = False
+            session.add(review)
+        raise HTTPRedirect('game_results?id={}&message={}', game_id, 'Reviews marked for sending!')
 
     def problems(self, session, game_id):
         game = session.indie_game(game_id)

--- a/mivs/templates/emails/reviews_summary.html
+++ b/mivs/templates/emails/reviews_summary.html
@@ -1,0 +1,18 @@
+{{ game.studio.primary_contact.first_name }},
+
+<br/><br/>Thank you so much for submitting your game to the {{ c.ESCHATON.year }} MAGFest Indie Videogame Showcase
+(MIVS). As a courtesy to developers, we send out summaries of the feedback each game received from our judges. Below
+is the list of judging results for your game submission ({{ game.title }}).
+
+<ul>
+  {% for review in game.reviews_to_email %}
+  <li>
+    {% if review.game_score %}<strong>Score:</strong> {{ review.game_score }}<br/>{% endif %}
+    <strong>Review Notes:</strong> {{ review.game_review|linebreaksbr }}
+  </li>
+  {% endfor %}
+</ul>
+
+<br/><br/>We hope this feedback helps you in your continued development of your game.
+
+<br/><br/>{{ c.MIVS_EMAIL_SIGNATURE|linebreaksbr }}

--- a/mivs/templates/mivs_admin/game_results.html
+++ b/mivs/templates/mivs_admin/game_results.html
@@ -38,6 +38,9 @@
     });
 </script>
 
+  <form method="post" action="send_reviews">
+  {{ csrf_token() }}
+  <input type="hidden" name="game_id" value="{{ game.id }}" />
 <table class="table">
 <thead>
     <tr>
@@ -46,6 +49,7 @@
         <th>Inappropriate Content?</th>
         <th>Score</th>
         <th>Notes</th>
+        <th>Send to Developer?</th>
     </tr>
 </thead>
 <tbody>
@@ -56,9 +60,18 @@
         <td>{{ review.game_content_bad|yesno }}</td>
         <td>{% if review.game_score %}{{ review.game_score }}{% endif %}</td>
         <td>{{ review.game_review|linebreaksbr }}</td>
+    <td><input type="checkbox" name="review_id" value="{{ review.id }}"
+               {% if review.send_to_studio %} checked {% endif %}/></td>
     </tr>
 {% endfor %}
 </tbody>
 </table>
+    <button type="submit" class="btn btn-primary"
+            {% if game.status not in c.FINAL_GAME_STATUSES %} disabled title="You can only send reviews after a game has been accepted, waitlisted, or declined!"{% endif %}>
+      Mark Reviews for Sending to Indie Studio</button>
+  <p class="help-block">Please note that once the "Summary of judging results for your game" email is
+    <a href="../emails/pending">approved for sending</a>, marking ANY reviews as ready to send will trigger an email to
+    the studio, after which editing the reviews to send will do nothing.</p>
+  </form>
 
 {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/magfest/mivs/issues/21 by allowing admins to mark judge reviews as "send to studio" using the game results page. Once the associated automated email is approved, any studio with reviews waiting to send will get an email with a summary of reviews per game. This allows admins to only send constructive judge reviews to studios, while automating the rest of the process.